### PR TITLE
Make it compatible with python <3.10

### DIFF
--- a/source/added_value/invoke.py
+++ b/source/added_value/invoke.py
@@ -1,4 +1,7 @@
-def parse_call(text: str) -> tuple[str, str]:
+from typing import Tuple
+
+
+def parse_call(text: str) -> Tuple[str, str]:
     """Parse a string containing a reference to a Python attribute or invocation thereof.
 
     Args:


### PR DESCRIPTION
We are using python 3.8 in our project and poetry to solve the dependencies. 

Since your project has no pyton version restiction poetry thinks that even using python 3.8 the latest version of `added-value` 0.24.0 is valid. 

But the new typing annotation is breaking backwards compatibility.

That's why I suggest using `Tuple` from typing.

@rob-smallshire is there any other file using this new typing annotations?